### PR TITLE
Added a config option to control output format.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -46,6 +46,8 @@ You can change some settings in config.json:
 
 "filter_parentheses" is True by default, which means it ignores subtitle lines that are completely enclosed in parentheses (including brackets and curly braces)
 
+"output_format" is set to "mp3" by default, but supports every output format supported by ffmpeg. Formats of note are "flac" as it is lossless, and "aac" since it supports higher quality audio at the same file size as mp3. For a complete list see ffmpeg's documentation.
+
 Project Web Page
 ---------------
 Visit https://ercanserteli.com/condenser for further information and future updates

--- a/README.txt
+++ b/README.txt
@@ -59,6 +59,9 @@ Condenser uses ffmpeg for manipulating video and audio files.
 
 Change log
 ----------
+v1.4.0
+  * Added the ability to control output file format, set by config
+
 v1.3.1
   * Fixed a bug with subtitles where some lines can be empty after filtering
 

--- a/condenser.py
+++ b/condenser.py
@@ -22,8 +22,8 @@ filter_parentheses = False
 output_format = ""
 
 
-def check_all_equal(l):
-    return l.count(l[0]) == len(l)
+def check_all_equal(li):
+    return li.count(li[0]) == len(li)
 
 
 def probe_video(filename):
@@ -42,14 +42,14 @@ def streams_to_options(streams):
     options = ["(No tag)"] * len(streams)
     for i, a in enumerate(streams):
         if "tags" in a:
-            lang = ""
-            title = ""
+            s_lang = ""
+            s_title = ""
             if "language" in a.get("tags"):
-                lang = a.get("tags").get("language")
+                s_lang = a.get("tags").get("language")
             if "title" in a.get("tags"):
-                title = a.get("tags").get("title")
-            if lang or title:
-                options[i] = "{}: {} ({})".format(i + 1, title, lang)
+                s_title = a.get("tags").get("title")
+            if s_lang or s_title:
+                options[i] = "{}: {} ({})".format(i + 1, s_title, s_lang)
     return options
 
 
@@ -58,8 +58,8 @@ def filter_text(text):
     if len(text) == 0:
         return ""
     if filter_parentheses and \
-            ((text[0] == "(" and text[-1] == ")") or \
-             (text[0] == "[" and text[-1] == "]") or \
+            ((text[0] == "(" and text[-1] == ")") or
+             (text[0] == "[" and text[-1] == "]") or
              (text[0] == "{" and text[-1] == "}")):
         return ""
     else:
@@ -107,7 +107,9 @@ def extract_audio_parts(periods, temp_dir, filename, audio_index):
     for i, (start, end) in enumerate(periods):
         out_path = temp_dir + "/out_{}.flac".format(i)
         out_paths.append(out_path)
-        command = [ffmpeg_cmd, '-hide_banner', '-loglevel', 'error', '-ss', str(start / 1000), '-i', filename, '-t', str((end - start) / 1000), '-map', '0:a:{}'.format(audio_index), '-c:a', 'flac', '-compression_level', '0', out_path]
+        command = [ffmpeg_cmd, '-hide_banner', '-loglevel', 'error', '-ss', str(start / 1000), '-i', filename, '-t',
+                   str((end - start) / 1000), '-map', '0:a:{}'.format(audio_index), '-c:a', 'flac',
+                   '-compression_level', '0', out_path]
         rc = sp.call(command, shell=False)
         if rc != 0:
             raise Exception("Could not extract audio from video")
@@ -135,7 +137,7 @@ def choose_audio_stream(audio_streams, message):
     if len(audio_streams) > 1:
         audio_options = streams_to_options(audio_streams)
         audio_index = g.indexbox(message, 'Audio Stream', audio_options, default_choice=audio_options[audio_index],
-                                 cancel_choice=None)
+                                 cancel_choice="cancel")
         if audio_index is None:
             raise Exception("Audio stream selection canceled. Exiting program.")
     return audio_index
@@ -145,18 +147,20 @@ def choose_subtitle_stream(subtitle_streams, mulsrt_ask, file_name_str="this fil
     sub_index = 0
     if len(subtitle_streams) > 1 and mulsrt_ask:
         sub_options = streams_to_options(subtitle_streams)
-        sub_index = g.indexbox('No external and multiple internal subtitles found in {}. Which one would you like to use?'.format(file_name_str) +
-                               ' If you want to always pick the first subtitle by default,'
-                               ' set "ask_when_multiple_srt" to False in config.json',
-                               'Subtitle Stream', sub_options, default_choice=sub_options[sub_index],
-                               cancel_choice=sub_options[sub_index])
+        sub_index = g.indexbox(
+            'No external and multiple internal subtitles found in {}. Which one would you like to use?'.format(
+                file_name_str) +
+            ' If you want to always pick the first subtitle by default,'
+            ' set "ask_when_multiple_srt" to False in config.json',
+            'Subtitle Stream', sub_options, default_choice=sub_options[sub_index],
+            cancel_choice=sub_options[sub_index])
     return sub_index
 
 
 def extract_srt(temp_dir, filename, sub_index):
     srt_path = op.join(temp_dir, "out.srt")
     result = sp.run([ffmpeg_cmd, '-hide_banner', '-loglevel', 'error', '-i', filename, '-map',
-                    '0:s:{}'.format(sub_index), srt_path], capture_output=True)
+                     '0:s:{}'.format(sub_index), srt_path], capture_output=True)
     if result.returncode != 0:
         raise Exception("Could not extract subtitle with ffmpeg: " + str(result.stderr))
     return srt_path
@@ -192,6 +196,7 @@ def get_srt(subtitle_streams, mulsrt_ask, file_folder, filename, temp_dir):
 
     return convert_sub_if_needed(sub_path, temp_dir)
 
+
 def convert_sub_if_needed(sub_path, temp_dir):
     sub_root, sub_ext = op.splitext(sub_path)
     if sub_ext.lower() != ".srt":
@@ -219,6 +224,7 @@ def condense(srt_path, padding, temp_dir, filename, audio_index, output_filename
 def condense_multi(subtitle_option, video_paths, video_names, subtitle_stream, audio_stream, mulsrt_ask, parent_folder,
                    folder_name, temp_dir, padding):
     all_subtitle_paths = list(map(find_same_name_sub, video_paths))
+    sub_index = 0
     if None in all_subtitle_paths:
         # There is at least one video with no external sub
         if len(subtitle_option) == 0:
@@ -274,9 +280,12 @@ def main():
                 conf = json.load(f)
                 padding = conf.get("padding")
                 mulsrt_ask = conf.get("ask_when_multiple_srt")
-                global filtered_chars; filtered_chars = conf.get("filtered_characters")
-                global filter_parentheses; filter_parentheses = conf.get("filter_parentheses")
-                global output_format; output_format = conf.get("output_format")
+                global filtered_chars
+                filtered_chars = conf.get("filtered_characters")
+                global filter_parentheses
+                filter_parentheses = conf.get("filter_parentheses")
+                global output_format
+                output_format = conf.get("output_format")
                 if type(padding) is not int or type(mulsrt_ask) is not bool:
                     raise Exception("Invalid config file")
                 if padding < 0:
@@ -291,10 +300,12 @@ def main():
         if len(sys.argv) > 1:
             filename = sys.argv[1]
         else:
-            answer = g.buttonbox("Would you like to condense one video or a folder of videos?\n"
-                                 "(You can also drag and drop videos or folders directly to the executable or its shortcut)", title, ["Video", "Folder"])
+            msg = "Would you like to condense one video or a folder of videos?\n" +\
+                "(You can also drag and drop videos or folders directly to the executable or its shortcut)"
+            answer = g.buttonbox(msg, title, ["Video", "Folder"])
             if answer == "Video":
-                filename = g.fileopenbox("Select video file", title, filetypes=[["*" + e for e in video_exts] + ["Video files"]])
+                filename = g.fileopenbox("Select video file", title,
+                                         filetypes=[["*" + e for e in video_exts] + ["Video files"]])
             elif answer == "Folder":
                 filename = g.diropenbox("Select folder", title)
 
@@ -328,11 +339,11 @@ def main():
                     found = False
                     for go in grouped_options:
                         if go[0][1] == o:
-                            go.append((i+1, o))
+                            go.append((i + 1, o))
                             found = True
                             break
                     if not found:
-                        grouped_options.append([(i+1, o)])
+                        grouped_options.append([(i + 1, o)])
 
                 for go in grouped_options:
                     ids = [i for i, o in go]
@@ -364,7 +375,8 @@ def main():
         with open(op.join(application_path, "log.txt"), "a") as f:
             time_str = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
             heading = time_str + " - " + filename
-            message = heading + "\n" + "-"*len(heading) + "\n" + str(ex) + "\nTraceback:\n" + traceback.format_exc() + "\n\n"
+            message = heading + "\n" + "-" * len(heading) + "\n" + str(
+                ex) + "\nTraceback:\n" + traceback.format_exc() + "\n\n"
             f.write(message)
         # os.system("pause")
 

--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
   "padding": 500,
   "ask_when_multiple_srt": true,
   "filtered_characters": "♩♪♫♬～",
-  "filter_parentheses": true
+  "filter_parentheses": true,
+  "output_format": "mp3"
 }

--- a/test.py
+++ b/test.py
@@ -1,96 +1,148 @@
+import json
 import subprocess as sp
 import unittest
 import os
 import shutil
+import inspect
 
 
 delete_outputs = True
 
 
-class TestSingles(unittest.TestCase):
+def current_function_name():
+    return inspect.currentframe().f_back.f_code.co_name
+
+
+def config_set(key, val):
+    shutil.copy("config.json", "config.json.bak")
+    with open("config.json", "r", encoding="utf-8") as f:
+        config = json.load(f)
+    config[key] = val
+    with open("config.json", "w", encoding="utf-8") as f:
+        json.dump(config, f)
+
+
+def restore_config():
+    if os.path.exists("config.json.bak"):
+        shutil.copy("config.json.bak", "config.json")
+        os.remove("config.json.bak")
+
+
+def create_test_class(base_class, output_format):
+    # noinspection PyPep8Naming
+    class TestClass(base_class):
+        _output_format = output_format
+
+        @classmethod
+        def setUpClass(cls):
+            print("Setting output format to {}".format(cls._output_format))
+            config_set("output_format", cls._output_format)
+
+        @classmethod
+        def tearDownClass(cls):
+            super().tearDownClass()
+            restore_config()
+
+    return TestClass
+
+
+class TestSinglesBase(unittest.TestCase):
+    _output_format = "mp3"
+
+    @classmethod
+    def tearDownClass(cls):
+        if delete_outputs:
+            for filename in ["test_vids/1a1s_con", "test_vids/3a1s_con", "test_vids/1a0s_con"]:
+                try:
+                    os.remove("{}.{}".format(filename, cls._output_format))
+                except Exception:
+                    pass
+
     def test1a1s(self):
-        result = sp.run(["python", "condenser.py", "test_vids\\1a1s.mkv"], capture_output=True)
+        print(current_function_name())
+        result = sp.run(["python", "condenser.py", "test_vids/1a1s.mkv"], capture_output=True)
         msg = str(result.stdout) + "\n" + str(result.stderr)
+        print(result.stdout)
         self.assertEqual(result.returncode, 0, msg)
         self.assertIn("Finished", str(result.stdout), msg)
-        print(result.stdout)
-        if delete_outputs:
-            os.remove("test_vids\\1a1s_con.mp3")
 
     def test3a1s(self):
-        result = sp.run(["python", "condenser.py", "test_vids\\3a1s.mkv"], capture_output=True)
+        print(current_function_name())
+        result = sp.run(["python", "condenser.py", "test_vids/3a1s.mkv"], capture_output=True)
         msg = str(result.stdout) + "\n" + str(result.stderr)
+        print(result.stdout)
         self.assertEqual(result.returncode, 0, msg)
         self.assertIn("Finished", str(result.stdout), msg)
+
+    def test1a0s(self):
+        print(current_function_name())
+        result = sp.run(["python", "condenser.py", "test_vids/1a0s.mkv"], capture_output=True)
+        msg = str(result.stdout) + "\n" + str(result.stderr)
         print(result.stdout)
-        if delete_outputs:
-            os.remove("test_vids\\3a1s_con.mp3")
+        self.assertEqual(result.returncode, 0, msg)
+        self.assertIn("Finished", str(result.stdout), msg)
 
     # def test3a2s(self):
-    #     result = sp.run(["python", "condenser.py", "test_vids\\3a2s.mkv"], capture_output=True)
+    #     print(current_function_name())
+    #     result = sp.run(["python", "condenser.py", "test_vids/3a2s.mkv"], capture_output=True)
     #     msg = str(result.stdout) + "\n" + str(result.stderr)
+    #     print(result.stdout)
     #     self.assertEqual(result.returncode, 0, msg)
     #     self.assertIn("Finished", str(result.stdout), msg)
-    #     print(result.stdout)
-    #     if delete_outputs:
-    #         os.remove("test_vids\\3a2s_con.mp3")
 
-    def test1a0s(self):
-        result = sp.run(["python", "condenser.py", "test_vids\\1a0s.mkv"], capture_output=True)
-        msg = str(result.stdout) + "\n" + str(result.stderr)
-        self.assertEqual(result.returncode, 0, msg)
-        self.assertIn("Finished", str(result.stdout), msg)
-        print(result.stdout)
+
+class TestFoldersBase(unittest.TestCase):
+    @classmethod
+    def tearDownClass(cls):
         if delete_outputs:
-            os.remove("test_vids\\1a0s_con.mp3")
+            for filename in ["test_vids/1a1s_con", "test_vids/3a1s_con", "test_vids/3a2s_con", "test_vids/1a0s_con",
+                             "test_vids/mix_con"]:
+                shutil.rmtree(filename, ignore_errors=True)
 
-
-class TestMultis(unittest.TestCase):
     def test1a1s(self):
-        result = sp.run(["python", "condenser.py", "test_vids\\1a1s"], capture_output=True)
+        print(current_function_name())
+        result = sp.run(["python", "condenser.py", "test_vids/1a1s"], capture_output=True)
         msg = str(result.stdout) + "\n" + str(result.stderr)
+        print(result.stdout)
         self.assertEqual(result.returncode, 0, msg)
         self.assertIn("Finished", str(result.stdout), msg)
-        print(result.stdout)
-        if delete_outputs:
-            shutil.rmtree("test_vids\\1a1s_con", ignore_errors=True)
 
     def test3a1s(self):
-        result = sp.run(["python", "condenser.py", "test_vids\\3a1s"], capture_output=True)
+        print(current_function_name())
+        result = sp.run(["python", "condenser.py", "test_vids/3a1s"], capture_output=True)
         msg = str(result.stdout) + "\n" + str(result.stderr)
+        print(result.stdout)
         self.assertEqual(result.returncode, 0, msg)
         self.assertIn("Finished", str(result.stdout), msg)
-        print(result.stdout)
-        if delete_outputs:
-            shutil.rmtree("test_vids\\3a1s_con", ignore_errors=True)
 
     def test3a2s(self):
-        result = sp.run(["python", "condenser.py", "test_vids\\3a2s"], capture_output=True)
+        print(current_function_name())
+        result = sp.run(["python", "condenser.py", "test_vids/3a2s"], capture_output=True)
         msg = str(result.stdout) + "\n" + str(result.stderr)
+        print(result.stdout)
         self.assertEqual(result.returncode, 0, msg)
         self.assertIn("Finished", str(result.stdout), msg)
-        print(result.stdout)
-        if delete_outputs:
-            shutil.rmtree("test_vids\\3a2s_con", ignore_errors=True)
 
     def test1a0s(self):
-        result = sp.run(["python", "condenser.py", "test_vids\\1a0s"], capture_output=True)
+        print(current_function_name())
+        result = sp.run(["python", "condenser.py", "test_vids/1a0s"], capture_output=True)
         msg = str(result.stdout) + "\n" + str(result.stderr)
+        print(result.stdout)
         self.assertEqual(result.returncode, 0, msg)
         self.assertIn("Finished", str(result.stdout), msg)
-        print(result.stdout)
-        if delete_outputs:
-            shutil.rmtree("test_vids\\1a0s_con", ignore_errors=True)
 
     def testmix(self):
-        result = sp.run(["python", "condenser.py", "test_vids\\mix"], capture_output=True)
+        print(current_function_name())
+        result = sp.run(["python", "condenser.py", "test_vids/mix"], capture_output=True)
         msg = str(result.stdout) + "\n" + str(result.stderr)
+        print(result.stdout)
         self.assertEqual(result.returncode, 0, msg)
         # self.assertIn("Videos in folder are not uniform", str(result.stdout), msg)
         self.assertIn("Finished", str(result.stdout), msg)
-        print(result.stdout)
-        if delete_outputs:
-            shutil.rmtree("test_vids\\mix_con", ignore_errors=True)
+
+
+TestSinglesFLAC = create_test_class(TestSinglesBase, "flac")
+TestFoldersFLAC = create_test_class(TestFoldersBase, "flac")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
These changes make it encode the parts to a lossless low compression setting flac as an intermediary (to prevent generational loss and for extra speed)
Then it encodes the final file to whatever format is specified in the config. This is file extension based, and supports every output format ffmpeg can output to.
Formats of note are: 
flac, which is especially useful if the user plans to run it through additional steps afterwards (ex. volume normalization, or down converting to mono). Since flac is a lossless format, this prevents generational loss from repeated lossy encodings. There's also a subset of users that just prefer flac for its lossless quality.
aac, this is a lossy format, and by default uses the same bitrate as mp3, but suffers less quality loss as it is a more efficient codec.

The default has been left as mp3 for its broad compatibility.